### PR TITLE
Typo in title

### DIFF
--- a/CloudAppSecurityDocs/tutorial-shadow-it.md
+++ b/CloudAppSecurityDocs/tutorial-shadow-it.md
@@ -1,5 +1,5 @@
 ---
-title: Discover and manager Shadow IT
+title: Discover and manage Shadow IT
 description: This tutorial describes the process to automatically apply Azure Information Protection classification labels in Microsoft Cloud App Security.
 ms.date: 06/29/2020
 ms.topic: tutorial


### PR DESCRIPTION
Quick removal of 'r' in 'manager' from header title property and link title property so it reads "Discover and manage Shadow IT" instead of "Discover and manager Shadow IT".

**From**
`<meta property="og:title" content="Discover and manager Shadow IT" />`
`<title>Discover and manager Shadow IT | Microsoft Docs</title>`

**To**
`<meta property="og:title" content="Discover and manage Shadow IT" />`
`<title>Discover and manage Shadow IT | Microsoft Docs</title>`